### PR TITLE
fix(datapath): decouple data config and regfile port config

### DIFF
--- a/src/main/scala/xiangshan/Parameters.scala
+++ b/src/main/scala/xiangshan/Parameters.scala
@@ -397,7 +397,7 @@ case class XSCoreParameters
       numPregs = intPreg.numEntries,
       numDeqOutside = 0,
       schdType = schdType,
-      rfDataWidth = intPreg.dataCfg.dataWidth,
+      rfDataWidth = intPreg.dataCfg.map(_.dataWidth).max,
       numUopIn = dpParams.IntDqDeqWidth,
     )
   }
@@ -425,7 +425,7 @@ case class XSCoreParameters
       numPregs = vfPreg.numEntries,
       numDeqOutside = 0,
       schdType = schdType,
-      rfDataWidth = vfPreg.dataCfg.dataWidth,
+      rfDataWidth = vfPreg.dataCfg.map(_.dataWidth).max,
       numUopIn = dpParams.VecDqDeqWidth,
     )
   }
@@ -448,7 +448,7 @@ case class XSCoreParameters
       numPregs = vfPreg.numEntries,
       numDeqOutside = 0,
       schdType = schdType,
-      rfDataWidth = vfPreg.dataCfg.dataWidth,
+      rfDataWidth = vfPreg.dataCfg.map(_.dataWidth).max,
       numUopIn = dpParams.VecDqDeqWidth,
     )
   }

--- a/src/main/scala/xiangshan/backend/Backend.scala
+++ b/src/main/scala/xiangshan/backend/Backend.scala
@@ -137,22 +137,22 @@ class BackendInlined(val params: BackendParams)(implicit p: Parameters) extends 
   }
 
   println(s"[Backend] Int RdConfigs: ExuName(Priority)")
-  for ((port, seq) <- params.getRdPortParams(IntData())) {
+  for ((port, seq) <- params.getRdPortParams(IntRD())) {
     println(s"[Backend]   port($port): ${seq.map(x => params.getExuName(x._1) + "(" + x._2.toString + ")").mkString(",")}")
   }
 
   println(s"[Backend] Int WbConfigs: ExuName(Priority)")
-  for ((port, seq) <- params.getWbPortParams(IntData())) {
+  for ((port, seq) <- params.getWbPortParams(IntWB())) {
     println(s"[Backend]   port($port): ${seq.map(x => params.getExuName(x._1) + "(" + x._2.toString + ")").mkString(",")}")
   }
 
   println(s"[Backend] Vf RdConfigs: ExuName(Priority)")
-  for ((port, seq) <- params.getRdPortParams(VecData())) {
+  for ((port, seq) <- params.getRdPortParams(VfRD())) {
     println(s"[Backend]   port($port): ${seq.map(x => params.getExuName(x._1) + "(" + x._2.toString + ")").mkString(",")}")
   }
 
   println(s"[Backend] Vf WbConfigs: ExuName(Priority)")
-  for ((port, seq) <- params.getWbPortParams(VecData())) {
+  for ((port, seq) <- params.getWbPortParams(VfWB())) {
     println(s"[Backend]   port($port): ${seq.map(x => params.getExuName(x._1) + "(" + x._2.toString + ")").mkString(",")}")
   }
 

--- a/src/main/scala/xiangshan/backend/BackendParams.scala
+++ b/src/main/scala/xiangshan/backend/BackendParams.scala
@@ -84,8 +84,16 @@ case class BackendParams(
   def vfPregParams: VfPregParams = pregParams.collectFirst { case x: VfPregParams => x }.get
   def v0PregParams: V0PregParams = pregParams.collectFirst { case x: V0PregParams => x }.get
   def vlPregParams: VlPregParams = pregParams.collectFirst { case x: VlPregParams => x }.get
-  def getPregParams: Map[DataConfig, PregParams] = {
-    pregParams.map(x => (x.dataCfg, x)).toMap
+  def fakeIntPregParams: FakeIntPregParams = pregParams.collectFirst { case x: FakeIntPregParams => x }.get
+  def getPregParams[T <: regPort](cfg : T): PregParams = {
+    cfg match {
+      case _: IntRD | _: IntWB => intPregParams
+      // case _: FpRD | _: FpWB => fpPregParams
+      case _: VfRD | _: VfWB => vfPregParams
+      case _: V0RD | _: V0WB => v0PregParams
+      case _: VlRD | _: VlWB => vlPregParams
+      case _ => fakeIntPregParams
+    }
   }
 
   def pregIdxWidth = pregParams.map(_.addrWidth).max
@@ -115,8 +123,8 @@ case class BackendParams(
   def numPcMemReadPort = allExuParams.filter(_.needPc).size
   def numTargetReadPort = allRealExuParams.count(x => x.needTarget)
 
-  def numPregRd(dataCfg: DataConfig) = this.getRfReadSize(dataCfg)
-  def numPregWb(dataCfg: DataConfig) = this.getRfWriteSize(dataCfg)
+  def numPregRd(pregParams: PregParams) = this.getRfReadSize(pregParams)
+  def numPregWb(pregParams: PregParams) = this.getRfWriteSize(pregParams)
 
   def numNoDataWB = allSchdParams.map(_.numNoDataWB).sum
   def numExu = allSchdParams.map(_.numExu).sum
@@ -137,24 +145,14 @@ case class BackendParams(
     this.fpSchdParams.get.issueBlockParams.map(x => Vec(x.numDeq, UInt((x.numEntries).U.getWidth.W)))
   }
 
-  def genIntWriteBackBundle(implicit p: Parameters) = {
-    Seq.fill(this.getIntRfWriteSize)(new RfWritePortWithConfig(IntData(), intPregParams.addrWidth))
-  }
+  def genIntWriteBackBundle(implicit p: Parameters) = genWriteBackBundle(intPregParams)
+  // def genFpWriteBackBundle(implicit p: Parameters) = genWriteBackBundle(fpPregParams)
+  def genVfWriteBackBundle(implicit p: Parameters) = genWriteBackBundle(vfPregParams)
+  def genV0WriteBackBundle(implicit p: Parameters) =  genWriteBackBundle(v0PregParams)
+  def genVlWriteBackBundle(implicit p: Parameters) = genWriteBackBundle(vlPregParams)
 
-  def genVfWriteBackBundle(implicit p: Parameters) = {
-    Seq.fill(this.getVfRfWriteSize)(new RfWritePortWithConfig(VecData(), vfPregParams.addrWidth))
-  }
-
-  def genV0WriteBackBundle(implicit p: Parameters) = {
-    Seq.fill(this.getV0RfWriteSize)(new RfWritePortWithConfig(V0Data(), v0PregParams.addrWidth))
-  }
-
-  def genVlWriteBackBundle(implicit p: Parameters) = {
-    Seq.fill(this.getVlRfWriteSize)(new RfWritePortWithConfig(VlData(), vlPregParams.addrWidth))
-  }
-
-  def genWriteBackBundles(implicit p: Parameters): Seq[RfWritePortWithConfig] = {
-    genIntWriteBackBundle ++ genVfWriteBackBundle
+  def genWriteBackBundle(pregParams: PregParams)(implicit p: Parameters): Seq[RfWritePortWithConfig] = {
+    Seq.fill(this.getRfWriteSize(pregParams))(new RfWritePortWithConfig(pregParams))
   }
 
   def genWrite2CtrlBundles(implicit p: Parameters): MixedVec[ValidIO[ExuOutput]] = {
@@ -187,11 +185,11 @@ case class BackendParams(
     * @param dataCfg [[IntData]] or [[VecData]]
     * @return Seq[port->Seq[(exuIdx, priority)]
     */
-  def getRdPortParams(dataCfg: DataConfig) = {
+  def getRdPortParams(cfg: RdConfig) = {
     // port -> Seq[exuIdx, priority]
     val cfgs: Seq[(Int, Seq[(Int, Int)])] = allRealExuParams
       .flatMap(x => x.rfrPortConfigs.flatten.map(xx => (xx, x.exuIdx)))
-      .filter { x => x._1.getDataConfig == dataCfg }
+      .filter { x => x._1.getClass == cfg.getClass }
       .map(x => (x._1.port, (x._2, x._1.priority)))
       .groupBy(_._1)
       .map(x => (x._1, x._2.map(_._2).sortBy({ case (priority, _) => priority })))
@@ -206,10 +204,10 @@ case class BackendParams(
     * @param dataCfg [[IntData]] or [[VecData]]
     * @return Seq[port->Seq[(exuIdx, priority)]
     */
-  def getWbPortParams(dataCfg: DataConfig) = {
+  def getWbPortParams(cfg: PregWB) = {
     val cfgs: Seq[(Int, Seq[(Int, Int)])] = allRealExuParams
       .flatMap(x => x.wbPortConfigs.map(xx => (xx, x.exuIdx)))
-      .filter { x => x._1.dataCfg == dataCfg }
+      .filter { x => x._1.getClass == cfg.getClass }
       .map(x => (x._1.port, (x._2, x._1.priority)))
       .groupBy(_._1)
       .map(x => (x._1, x._2.map(_._2)))
@@ -218,12 +216,12 @@ case class BackendParams(
     cfgs
   }
 
-  def getRdPortIndices(dataCfg: DataConfig) = {
-    this.getRdPortParams(dataCfg).map(_._1)
+  def getRdPortIndices(cfg: RdConfig) = {
+    this.getRdPortParams(cfg).map(_._1)
   }
 
-  def getWbPortIndices(dataCfg: DataConfig) = {
-    this.getWbPortParams(dataCfg).map(_._1)
+  def getWbPortIndices(cfg: PregWB) = {
+    this.getWbPortParams(cfg).map(_._1)
   }
 
   def getRdCfgs[T <: RdConfig](implicit tag: ClassTag[T]): Seq[Seq[Seq[RdConfig]]] = {
@@ -247,64 +245,13 @@ case class BackendParams(
     wbCfgs
   }
 
-  /**
-    * Get size of read ports of int regfile
-    *
-    * @return if [[IntPregParams.numRead]] is [[None]], get size of ports in [[IntRD]]
-    */
-  def getIntRfReadSize = {
-    this.intPregParams.numRead.getOrElse(this.getRdPortIndices(IntData()).size)
+  def getRfReadSize(pregParams: PregParams) = {
+    pregParams.numRead.getOrElse(this.getRdPortIndices(pregParams.rdType).size)
   }
 
-  /**
-    * Get size of write ports of int regfile
-    *
-    * @return if [[IntPregParams.numWrite]] is [[None]], get size of ports in [[IntWB]]
-    */
-  def getIntRfWriteSize = {
-    this.intPregParams.numWrite.getOrElse(this.getWbPortIndices(IntData()).size)
+  def getRfWriteSize(pregParams: PregParams) = {
+    pregParams.numWrite.getOrElse(this.getWbPortIndices(pregParams.wbType).size)
   }
-
-  /**
-    * Get size of read ports of vec regfile
-    *
-    * @return if [[VfPregParams.numRead]] is [[None]], get size of ports in [[VfRD]]
-    */
-  def getVfRfReadSize = {
-    this.vfPregParams.numRead.getOrElse(this.getRdPortIndices(VecData()).size)
-  }
-
-  /**
-    * Get size of write ports of vec regfile
-    *
-    * @return if [[VfPregParams.numWrite]] is [[None]], get size of ports in [[VfWB]]
-    */
-  def getVfRfWriteSize = {
-    this.vfPregParams.numWrite.getOrElse(this.getWbPortIndices(VecData()).size)
-  }
-
-  def getV0RfWriteSize = {
-    this.v0PregParams.numWrite.getOrElse(this.getWbPortIndices(V0Data()).size)
-  }
-
-  def getVlRfWriteSize = {
-    this.vlPregParams.numWrite.getOrElse(this.getWbPortIndices(VlData()).size)
-  }
-
-  def getRfReadSize(dataCfg: DataConfig) = {
-    dataCfg match{
-      case IntData() => this.getPregParams(dataCfg).numRead.getOrElse(this.getRdPortIndices(dataCfg).size)
-      case VecData() => this.getPregParams(dataCfg).numRead.getOrElse(this.getRdPortIndices(dataCfg).size)
-      case V0Data() => this.getPregParams(dataCfg).numRead.getOrElse(this.getRdPortIndices(dataCfg).size)
-      case VlData() => this.getPregParams(dataCfg).numRead.getOrElse(this.getRdPortIndices(dataCfg).size)
-      case _ => throw new IllegalArgumentException(s"DataConfig ${dataCfg} can not get RfReadSize")
-    }
-  }
-
-  def getRfWriteSize(dataCfg: DataConfig) = {
-    this.getPregParams(dataCfg).numWrite.getOrElse(this.getWbPortIndices(dataCfg).size)
-  }
-
 
   /**
     * Get size of read ports of int regcache
@@ -372,7 +319,7 @@ case class BackendParams(
   def checkReadPortContinuous = {
     pregParams.filterNot(_.isFake).foreach { x =>
       if (x.numRead.isEmpty) {
-        val portIndices: Seq[Int] = getRdPortIndices(x.dataCfg)
+        val portIndices: Seq[Int] = getRdPortIndices(x.rdType)
         require(isContinuous(portIndices),
           s"The read ports of ${x.getClass.getSimpleName} should be continuous, " +
             s"when numRead of ${x.getClass.getSimpleName} is None. The read port indices are $portIndices")
@@ -383,7 +330,7 @@ case class BackendParams(
   def checkWritePortContinuous = {
     pregParams.filterNot(_.isFake).foreach { x =>
       if (x.numWrite.isEmpty) {
-        val portIndices: Seq[Int] = getWbPortIndices(x.dataCfg)
+        val portIndices: Seq[Int] = getWbPortIndices(x.wbType)
         require(
           isContinuous(portIndices),
           s"The write ports of ${x.getClass.getSimpleName} should be continuous, " +

--- a/src/main/scala/xiangshan/backend/Bundles.scala
+++ b/src/main/scala/xiangshan/backend/Bundles.scala
@@ -591,7 +591,7 @@ object Bundles {
 
     val rf: MixedVec[MixedVec[RfReadPortWithConfig]] = Flipped(MixedVec(
       rfReadDataCfgSet.map((set: Set[DataConfig]) =>
-        MixedVec(set.map((x: DataConfig) => new RfReadPortWithConfig(x, exuParams.rdPregIdxWidth)).toSeq)
+        MixedVec(set.map((x: DataConfig) => new RfReadPortWithConfig(exuParams.rdPregIdxWidth)).toSeq)
       )
     ))
 
@@ -866,7 +866,7 @@ object Bundles {
     }
 
     def asIntRfWriteBundle(fire: Bool): RfWritePortWithConfig = {
-      val rfWrite = Wire(Output(new RfWritePortWithConfig(this.params.dataCfg, backendParams.getPregParams(IntData()).addrWidth)))
+      val rfWrite = Wire(Output(new RfWritePortWithConfig(backendParams.intPregParams)))
       rfWrite.wen := this.rfWen && fire
       rfWrite.addr := this.pdest
       rfWrite.data := this.data
@@ -879,7 +879,7 @@ object Bundles {
     }
 
     def asVfRfWriteBundle(fire: Bool): RfWritePortWithConfig = {
-      val rfWrite = Wire(Output(new RfWritePortWithConfig(this.params.dataCfg, backendParams.getPregParams(VecData()).addrWidth)))
+      val rfWrite = Wire(Output(new RfWritePortWithConfig(backendParams.vfPregParams)))
       rfWrite.wen := this.vecWen && fire
       rfWrite.addr := this.pdest
       rfWrite.data := this.data
@@ -892,7 +892,7 @@ object Bundles {
     }
 
     def asV0RfWriteBundle(fire: Bool): RfWritePortWithConfig = {
-      val rfWrite = Wire(Output(new RfWritePortWithConfig(this.params.dataCfg, backendParams.getPregParams(V0Data()).addrWidth)))
+      val rfWrite = Wire(Output(new RfWritePortWithConfig(backendParams.v0PregParams)))
       rfWrite.wen := this.v0Wen && fire
       rfWrite.addr := this.pdest
       rfWrite.data := this.data
@@ -905,7 +905,7 @@ object Bundles {
     }
 
     def asVlRfWriteBundle(fire: Bool): RfWritePortWithConfig = {
-      val rfWrite = Wire(Output(new RfWritePortWithConfig(this.params.dataCfg, backendParams.getPregParams(VlData()).addrWidth)))
+      val rfWrite = Wire(Output(new RfWritePortWithConfig(backendParams.vlPregParams)))
       rfWrite.wen := this.vlWen && fire
       rfWrite.addr := this.pdest
       rfWrite.data := this.data

--- a/src/main/scala/xiangshan/backend/datapath/DataConfig.scala
+++ b/src/main/scala/xiangshan/backend/datapath/DataConfig.scala
@@ -13,6 +13,7 @@ object DataConfig {
   }
 
   case class IntData() extends DataConfig("int", 64)
+  case class FpData() extends DataConfig("fp", 64)
   case class VecData() extends DataConfig("vec", 128)
   case class ImmData(len: Int) extends DataConfig("int", len)
   case class VAddrData()(implicit p: Parameters) extends DataConfig("vaddr", 48 + 2) // Todo: associate it with the width of vaddr
@@ -21,9 +22,10 @@ object DataConfig {
   case class FakeIntData() extends DataConfig("fakeint", 64)
   case class NoData() extends DataConfig("nodata", 0)
 
-  def RegSrcDataSet   : Set[DataConfig] = Set(IntData(), VecData(), V0Data(), VlData())
+  def RegSrcDataSet   : Set[DataConfig] = Set(IntData(), FpData(), VecData(), V0Data(), VlData())
   def IntRegSrcDataSet: Set[DataConfig] = Set(IntData())
-  def VecRegSrcDataSet : Set[DataConfig] = Set(VecData())
+  // def FpRegSrcDataSet : Set[DataConfig] = Set(FpData())
+  def VecRegSrcDataSet : Set[DataConfig] = Set(VecData(), FpData())
   def V0RegSrcDataSet : Set[DataConfig] = Set(V0Data())
   def VlRegSrcDataSet : Set[DataConfig] = Set(VlData())
 

--- a/src/main/scala/xiangshan/backend/datapath/DataPath.scala
+++ b/src/main/scala/xiangshan/backend/datapath/DataPath.scala
@@ -29,10 +29,11 @@ class DataPath(params: BackendParams)(implicit p: Parameters) extends LazyModule
   lazy val module = new DataPathImp(this)
 
   println(s"[DataPath] Preg Params: ")
-  println(s"[DataPath]   Int R(${params.getRfReadSize(IntData())}), W(${params.getRfWriteSize(IntData())}) ")
-  println(s"[DataPath]   Vf R(${params.getRfReadSize(VecData())}), W(${params.getRfWriteSize(VecData())}) ")
-  println(s"[DataPath]   V0 R(${params.getRfReadSize(V0Data())}), W(${params.getRfWriteSize(V0Data())}) ")
-  println(s"[DataPath]   Vl R(${params.getRfReadSize(VlData())}), W(${params.getRfWriteSize(VlData())}) ")
+  println(s"[DataPath]   Int R(${params.getRfReadSize(params.intPregParams)}), W(${params.getRfWriteSize(params.intPregParams)}) ")
+  // println(s"[DataPath]   Fp R(${params.getRfReadSize(prarms.fpPregParams)}), W(${params.getRfWriteSize(params.fpPregParams)}) ")
+  println(s"[DataPath]   Vf R(${params.getRfReadSize(params.vfPregParams)}), W(${params.getRfWriteSize(params.vfPregParams)}) ")
+  println(s"[DataPath]   V0 R(${params.getRfReadSize(params.v0PregParams)}), W(${params.getRfWriteSize(params.v0PregParams)}) ")
+  println(s"[DataPath]   Vl R(${params.getRfReadSize(params.vlPregParams)}), W(${params.getRfWriteSize(params.vlPregParams)}) ")
 }
 
 class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params: BackendParams)
@@ -199,28 +200,28 @@ class DataPathImp(override val wrapper: DataPath)(implicit p: Parameters, params
   private val pcReadFtqOffset = Wire(chiselTypeOf(io.fromPcTargetMem.fromDataPathFtqOffset))
   private val targetPCRdata = io.fromPcTargetMem.toDataPathTargetPC
   private val pcRdata = io.fromPcTargetMem.toDataPathPC
-  private val intRfRaddr = Wire(Vec(params.numPregRd(IntData()), UInt(intSchdParams.pregIdxWidth.W)))
-  private val intRfRdata = Wire(Vec(params.numPregRd(IntData()), UInt(intSchdParams.rfDataWidth.W)))
+  private val intRfRaddr = Wire(Vec(params.numPregRd(params.intPregParams), UInt(intSchdParams.pregIdxWidth.W)))
+  private val intRfRdata = Wire(Vec(params.numPregRd(params.intPregParams), UInt(intSchdParams.rfDataWidth.W)))
   private val intRfWen = Wire(Vec(io.fromIntWb.length, Bool()))
   private val intRfWaddr = Wire(Vec(io.fromIntWb.length, UInt(intSchdParams.pregIdxWidth.W)))
   private val intRfWdata = Wire(Vec(io.fromIntWb.length, UInt(intSchdParams.rfDataWidth.W)))
 
   private val vfRfSplitNum = VLEN / XLEN
-  private val vfRfRaddr = Wire(Vec(params.numPregRd(VecData()), UInt(vfSchdParams.pregIdxWidth.W)))
-  private val vfRfRdata = Wire(Vec(params.numPregRd(VecData()), UInt(vfSchdParams.rfDataWidth.W)))
+  private val vfRfRaddr = Wire(Vec(params.numPregRd(params.vfPregParams), UInt(vfSchdParams.pregIdxWidth.W)))
+  private val vfRfRdata = Wire(Vec(params.numPregRd(params.vfPregParams), UInt(vfSchdParams.rfDataWidth.W)))
   private val vfRfWen = Wire(Vec(vfRfSplitNum, Vec(io.fromVfWb.length, Bool())))
   private val vfRfWaddr = Wire(Vec(io.fromVfWb.length, UInt(vfSchdParams.pregIdxWidth.W)))
   private val vfRfWdata = Wire(Vec(io.fromVfWb.length, UInt(vfSchdParams.rfDataWidth.W)))
 
   private val v0RfSplitNum = VLEN / XLEN
-  private val v0RfRaddr = Wire(Vec(params.numPregRd(V0Data()), UInt(log2Up(V0PhyRegs).W)))
-  private val v0RfRdata = Wire(Vec(params.numPregRd(V0Data()), UInt(V0Data().dataWidth.W)))
+  private val v0RfRaddr = Wire(Vec(params.numPregRd(params.v0PregParams), UInt(log2Up(V0PhyRegs).W)))
+  private val v0RfRdata = Wire(Vec(params.numPregRd(params.v0PregParams), UInt(V0Data().dataWidth.W)))
   private val v0RfWen = Wire(Vec(v0RfSplitNum, Vec(io.fromV0Wb.length, Bool())))
   private val v0RfWaddr = Wire(Vec(io.fromV0Wb.length, UInt(log2Up(V0PhyRegs).W)))
   private val v0RfWdata = Wire(Vec(io.fromV0Wb.length, UInt(V0Data().dataWidth.W)))
 
-  private val vlRfRaddr = Wire(Vec(params.numPregRd(VlData()), UInt(log2Up(VlPhyRegs).W)))
-  private val vlRfRdata = Wire(Vec(params.numPregRd(VlData()), UInt(VlData().dataWidth.W)))
+  private val vlRfRaddr = Wire(Vec(params.numPregRd(params.vlPregParams), UInt(log2Up(VlPhyRegs).W)))
+  private val vlRfRdata = Wire(Vec(params.numPregRd(params.vlPregParams), UInt(VlData().dataWidth.W)))
   private val vlRfWen = Wire(Vec(io.fromVlWb.length, Bool()))
   private val vlRfWaddr = Wire(Vec(io.fromVlWb.length, UInt(log2Up(VlPhyRegs).W)))
   private val vlRfWdata = Wire(Vec(io.fromVlWb.length, UInt(VlData().dataWidth.W)))

--- a/src/main/scala/xiangshan/backend/datapath/RFReadArbiter.scala
+++ b/src/main/scala/xiangshan/backend/datapath/RFReadArbiter.scala
@@ -118,7 +118,7 @@ class IntRFReadArbiter(
 )(implicit
   p: Parameters
 ) extends RFReadArbiterBase(RFRdArbParams(backendParams.getRdCfgs[IntRD], backendParams.intPregParams)) {
-  override protected def portRange: Range = 0 to backendParams.getRdPortIndices(IntData()).max
+  override protected def portRange: Range = 0 to backendParams.getRdPortIndices(IntRD()).max
 }
 
 // class FpRFReadArbiter(
@@ -126,7 +126,7 @@ class IntRFReadArbiter(
 // )(implicit
 //   p: Parameters
 // ) extends RFReadArbiterBase(RFRdArbParams(backendParams.getRdCfgs[FpRD], backendParams.fpPregParams)) {
-//   override protected def portRange: Range = 0 to backendParams.getRdPortIndices(FpData()).max
+//   override protected def portRange: Range = 0 to backendParams.getRdPortIndices(VfRD).max
 // }
 
 class VfRFReadArbiter(
@@ -134,7 +134,7 @@ class VfRFReadArbiter(
 )(implicit
   p: Parameters
 ) extends RFReadArbiterBase(RFRdArbParams(backendParams.getRdCfgs[VfRD], backendParams.vfPregParams)) {
-  override protected def portRange: Range = 0 to backendParams.getRdPortIndices(VecData()).max
+  override protected def portRange: Range = 0 to backendParams.getRdPortIndices(VfRD()).max
 }
 
 class V0RFReadArbiter(
@@ -142,7 +142,7 @@ class V0RFReadArbiter(
 )(implicit
   p: Parameters
 ) extends RFReadArbiterBase(RFRdArbParams(backendParams.getRdCfgs[V0RD], backendParams.v0PregParams)) {
-  override protected def portRange: Range = 0 to backendParams.getRdPortIndices(V0Data()).max
+  override protected def portRange: Range = 0 to backendParams.getRdPortIndices(V0RD()).max
 }
 
 class VlRFReadArbiter(
@@ -150,5 +150,5 @@ class VlRFReadArbiter(
 )(implicit
   p: Parameters
 ) extends RFReadArbiterBase(RFRdArbParams(backendParams.getRdCfgs[VlRD], backendParams.vlPregParams)) {
-  override protected def portRange: Range = 0 to backendParams.getRdPortIndices(VlData()).max
+  override protected def portRange: Range = 0 to backendParams.getRdPortIndices(VlRD()).max
 }

--- a/src/main/scala/xiangshan/backend/datapath/RFWBConflictChecker.scala
+++ b/src/main/scala/xiangshan/backend/datapath/RFWBConflictChecker.scala
@@ -9,6 +9,11 @@ import xiangshan.backend.BackendParams
 import xiangshan.backend.datapath.DataConfig._
 import xiangshan.backend.datapath.WbConfig.{NoWB, PregWB}
 import xiangshan.backend.regfile.PregParams
+import xiangshan.backend.datapath.RdConfig.IntRD
+import xiangshan.backend.datapath.WbConfig.IntWB
+import xiangshan.backend.datapath.WbConfig.VfWB
+import xiangshan.backend.datapath.WbConfig.V0WB
+import xiangshan.backend.datapath.WbConfig.VlWB
 
 case class RFWBCollideCheckerParams (
   inWbCfgs: Seq[Seq[Set[PregWB]]],
@@ -186,7 +191,7 @@ class IntRFWBCollideChecker(
 )(implicit
   p:Parameters
 ) extends RFWBCollideCheckerBase(RFWBCollideCheckerParams(backendParams.getAllWbCfgs, backendParams.intPregParams)) {
-  override protected def portRange: Range = 0 to backendParams.getWbPortIndices(IntData()).max
+  override protected def portRange: Range = 0 to backendParams.getWbPortIndices(IntWB()).max
 }
 
 // class FpRFWBCollideChecker(
@@ -194,7 +199,7 @@ class IntRFWBCollideChecker(
 // )(implicit
 //   p:Parameters
 // ) extends RFWBCollideCheckerBase(RFWBCollideCheckerParams(backendParams.getAllWbCfgs, backendParams.vfPregParams)) {
-//   override protected def portRange: Range = 0 to backendParams.getWbPortIndices(FpData()).max
+//   override protected def portRange: Range = 0 to backendParams.getWbPortIndices(FpRD()).max
 // }
 
 class VfRFWBCollideChecker(
@@ -202,7 +207,7 @@ class VfRFWBCollideChecker(
 )(implicit
   p:Parameters
 ) extends RFWBCollideCheckerBase(RFWBCollideCheckerParams(backendParams.getAllWbCfgs, backendParams.vfPregParams)) {
-  override protected def portRange: Range = 0 to backendParams.getWbPortIndices(VecData()).max
+  override protected def portRange: Range = 0 to backendParams.getWbPortIndices(VfWB()).max
 }
 
 class V0RFWBCollideChecker(
@@ -210,7 +215,7 @@ class V0RFWBCollideChecker(
 )(implicit
   p:Parameters
 ) extends RFWBCollideCheckerBase(RFWBCollideCheckerParams(backendParams.getAllWbCfgs, backendParams.v0PregParams)) {
-  override protected def portRange: Range = 0 to backendParams.getWbPortIndices(V0Data()).max
+  override protected def portRange: Range = 0 to backendParams.getWbPortIndices(V0WB()).max
 }
 
 class VlRFWBCollideChecker(
@@ -218,5 +223,5 @@ class VlRFWBCollideChecker(
 )(implicit
   p:Parameters
 ) extends RFWBCollideCheckerBase(RFWBCollideCheckerParams(backendParams.getAllWbCfgs, backendParams.vlPregParams)) {
-  override protected def portRange: Range = 0 to backendParams.getWbPortIndices(VlData()).max
+  override protected def portRange: Range = 0 to backendParams.getWbPortIndices(VlWB()).max
 }

--- a/src/main/scala/xiangshan/backend/datapath/RdConfig.scala
+++ b/src/main/scala/xiangshan/backend/datapath/RdConfig.scala
@@ -1,33 +1,34 @@
 package xiangshan.backend.datapath
 
 import xiangshan.backend.datapath.DataConfig._
+import xiangshan.backend.regfile.regPort
 
 object RdConfig {
-  sealed abstract class RdConfig() {
+  sealed abstract class RdConfig() extends regPort {
     val port: Int
     val priority: Int
 
-    def getDataConfig: DataConfig
+    def getDataConfig: Set[DataConfig]
   }
 
   case class IntRD(port: Int = -1, priority: Int = Int.MaxValue) extends RdConfig() {
-    override def getDataConfig = IntData()
+    override def getDataConfig = Set(IntData())
   }
 
-  // case class FpRD(port: Int = -1, priority: Int = Int.MaxValue) extends RdConfig() {
-  //   override def getDataConfig = FpData()
-  // }
+  case class FpRD(port: Int = -1, priority: Int = Int.MaxValue) extends RdConfig() {
+    override def getDataConfig = Set(FpData())
+  }
 
   case class VfRD(port: Int = -1, priority: Int = Int.MaxValue) extends RdConfig() {
-    override def getDataConfig = VecData()
+    override def getDataConfig = Set(FpData(), VecData())
   }
 
   case class V0RD(port: Int = -1, priority: Int = Int.MaxValue) extends RdConfig() {
-    override def getDataConfig = V0Data()
+    override def getDataConfig = Set(V0Data())
   }
 
   case class VlRD(port: Int = -1, priority: Int = Int.MaxValue) extends RdConfig() {
-    override def getDataConfig = VlData()
+    override def getDataConfig = Set(VlData())
   }
 
   case class NoRD() extends RdConfig() {
@@ -35,7 +36,7 @@ object RdConfig {
 
     override val priority: Int = Int.MaxValue
 
-    override def getDataConfig: DataConfig = NoData()
+    override def getDataConfig: Set[DataConfig] = Set()
   }
 }
 

--- a/src/main/scala/xiangshan/backend/datapath/WbArbiter.scala
+++ b/src/main/scala/xiangshan/backend/datapath/WbArbiter.scala
@@ -12,6 +12,7 @@ import xiangshan.backend.regfile.RfWritePortWithConfig
 import xiangshan.{Redirect, XSBundle, XSModule}
 import xiangshan.SrcType.v0
 import xiangshan.backend.fu.vector.Bundles.Vstart
+import xiangshan.backend.datapath.WbConfig._
 
 class WbArbiterDispatcherIO[T <: Data](private val gen: T, n: Int) extends Bundle {
   val in = Flipped(DecoupledIO(gen))
@@ -101,20 +102,15 @@ class WbDataPathIO()(implicit p: Parameters, params: BackendParams) extends XSBu
     val vstart = Vstart()
   })
 
-  val toIntPreg = Flipped(MixedVec(Vec(params.numPregWb(IntData()),
-    new RfWritePortWithConfig(params.intPregParams.dataCfg, params.intPregParams.addrWidth))))
+  val toIntPreg = Flipped(MixedVec(Vec(params.numPregWb(params.intPregParams), new RfWritePortWithConfig(params.intPregParams))))
 
-  // val toFpPreg = Flipped(MixedVec(Vec(params.numPregWb(FpData()),
-  //   new RfWritePortWithConfig(params.vfPregParams.dataCfg, params.vfPregParams.addrWidth))))
+  // val toFpPreg = Flipped(MixedVec(Vec(params.numPregWb(params.numPregWb(params.fpPregParams), new RfWritePortWithConfig(params.vfPregParams))))
 
-  val toVfPreg = Flipped(MixedVec(Vec(params.numPregWb(VecData()),
-    new RfWritePortWithConfig(params.vfPregParams.dataCfg, params.vfPregParams.addrWidth))))
+  val toVfPreg = Flipped(MixedVec(Vec(params.numPregWb(params.vfPregParams), new RfWritePortWithConfig(params.vfPregParams))))
 
-  val toV0Preg = Flipped(MixedVec(Vec(params.numPregWb(V0Data()),
-    new RfWritePortWithConfig(params.v0PregParams.dataCfg, params.v0PregParams.addrWidth))))
+  val toV0Preg = Flipped(MixedVec(Vec(params.numPregWb(params.v0PregParams), new RfWritePortWithConfig(params.v0PregParams))))
 
-  val toVlPreg = Flipped(MixedVec(Vec(params.numPregWb(VlData()),
-    new RfWritePortWithConfig(params.vlPregParams.dataCfg, params.vlPregParams.addrWidth))))
+  val toVlPreg = Flipped(MixedVec(Vec(params.numPregWb(params.vlPregParams), new RfWritePortWithConfig(params.vlPregParams))))
 
   val toCtrlBlock = new Bundle {
     val writeback: MixedVec[ValidIO[ExuOutput]] = params.genWrite2CtrlBundles

--- a/src/main/scala/xiangshan/backend/exu/ExeUnitParams.scala
+++ b/src/main/scala/xiangshan/backend/exu/ExeUnitParams.scala
@@ -131,11 +131,11 @@ case class ExeUnitParams(
     1 + setIQ.size / copyDistance
   }
   def rdPregIdxWidth: Int = {
-    this.pregRdDataCfgSet.map(dataCfg => backendParam.getPregParams(dataCfg).addrWidth).fold(0)(_ max _)
+    this.pregRdCfgSet.map(rdCfg => backendParam.getPregParams(rdCfg).addrWidth).fold(0)(_ max _)
   }
 
   def wbPregIdxWidth: Int = {
-    this.pregWbDataCfgSet.map(dataCfg => backendParam.getPregParams(dataCfg).addrWidth).fold(0)(_ max _)
+    this.pregWbCfgSet.map(wbCfg => backendParam.getPregParams(wbCfg).addrWidth).fold(0)(_ max _)
   }
 
   val writeIntFuConfigs: Seq[FuConfig] = fuConfigs.filter(x => x.writeIntRf)
@@ -370,15 +370,15 @@ case class ExeUnitParams(
   /**
     * Get the [[DataConfig]] that this exu need to read
     */
-  def pregRdDataCfgSet: Set[DataConfig] = {
-    this.rfrPortConfigs.flatten.map(_.getDataConfig).toSet
+  def pregRdCfgSet: Set[RdConfig] = {
+    this.rfrPortConfigs.flatten.toSet
   }
 
   /**
     * Get the [[DataConfig]] that this exu need to write
     */
-  def pregWbDataCfgSet: Set[DataConfig] = {
-    this.wbPortConfigs.map(_.dataCfg).toSet
+  def pregWbCfgSet: Set[PregWB] = {
+    this.wbPortConfigs.toSet
   }
 
   def getRfReadDataCfgSet: Seq[Set[DataConfig]] = {

--- a/src/main/scala/xiangshan/backend/fu/FuConfig.scala
+++ b/src/main/scala/xiangshan/backend/fu/FuConfig.scala
@@ -278,8 +278,8 @@ object FuConfig {
     FuType.f2v,
     fuGen = (p: Parameters, cfg: FuConfig) => Module(new IntFPToVec(cfg)(p).suggestName("f2v")),
     srcData = Seq(
-      Seq(VecData(), VecData()),
-      Seq(VecData()),
+      Seq(FpData(), FpData()),
+      Seq(FpData()),
     ),
     piped = true,
     // writeFpRf = true,
@@ -449,7 +449,7 @@ object FuConfig {
     fuGen = (p: Parameters, cfg: FuConfig) => Module(new Std(cfg)(p).suggestName("Std")),
     srcData = Seq(
       Seq(IntData()),
-      Seq(VecData()),
+      Seq(FpData()),
     ),
     piped = true,
     latency = CertainLatency(0)
@@ -694,7 +694,7 @@ object FuConfig {
     fuType = FuType.falu,
     fuGen = (p: Parameters, cfg: FuConfig) => Module(new FAlu(cfg)(p).suggestName("Falu")),
     srcData = Seq(
-      Seq(VecData(), VecData()),
+      Seq(FpData(), FpData()),
     ),
     piped = true,
     writeVecRf = true,
@@ -710,7 +710,7 @@ object FuConfig {
     fuType = FuType.fmac,
     fuGen = (p: Parameters, cfg: FuConfig) => Module(new FMA(cfg)(p).suggestName("Fmac")),
     srcData = Seq(
-      Seq(VecData(), VecData(), VecData()),
+      Seq(FpData(), FpData(), FpData()),
     ),
     piped = true,
     writeVecRf = true,
@@ -725,7 +725,7 @@ object FuConfig {
     fuType = FuType.fDivSqrt,
     fuGen = (p: Parameters, cfg: FuConfig) => Module(new FDivSqrt(cfg)(p).suggestName("Fdiv")),
     srcData = Seq(
-      Seq(VecData(), VecData()),
+      Seq(FpData(), FpData()),
     ),
     piped = false,
     writeVecRf = true,
@@ -740,7 +740,7 @@ object FuConfig {
     fuType = FuType.fcvt,
     fuGen = (p: Parameters, cfg: FuConfig) => Module(new FCVT(cfg)(p).suggestName("Fcvt")),
     srcData = Seq(
-      Seq(VecData()),
+      Seq(FpData()),
     ),
     piped = true,
     writeVecRf = true,

--- a/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
+++ b/src/main/scala/xiangshan/backend/issue/IssueBlockParams.scala
@@ -8,6 +8,7 @@ import xiangshan.backend.BackendParams
 import xiangshan.backend.Bundles._
 import xiangshan.backend.datapath.DataConfig.DataConfig
 import xiangshan.backend.datapath.WbConfig._
+import xiangshan.backend.datapath.RdConfig._
 import xiangshan.backend.datapath.{WakeUpConfig, WakeUpSource}
 import xiangshan.backend.exu.{ExeUnit, ExeUnitParams}
 import xiangshan.backend.fu.{FuConfig, FuType}
@@ -213,12 +214,12 @@ case class IssueBlockParams(
   /**
     * Get the regfile type that this issue queue need to read
     */
-  def pregReadSet: Set[DataConfig] = exuBlockParams.map(_.pregRdDataCfgSet).fold(Set())(_ union _)
+  def pregReadSet: Set[RdConfig] = exuBlockParams.map(_.pregRdCfgSet).fold(Set())(_ union _)
 
   /**
     * Get the regfile type that this issue queue need to read
     */
-  def pregWriteSet: Set[DataConfig] = exuBlockParams.map(_.pregWbDataCfgSet).fold(Set())(_ union _)
+  def pregWriteSet: Set[PregWB] = exuBlockParams.map(_.pregWbCfgSet).fold(Set())(_ union _)
 
   /**
     * Get the max width of psrc
@@ -272,7 +273,7 @@ case class IssueBlockParams(
 
   def numWakeupFromWB = {
     val pregSet = this.pregReadSet
-    pregSet.map(cfg => backendParam.getRfWriteSize(cfg)).sum
+    pregSet.map(cfg => backendParam.getRfWriteSize(backendParam.getPregParams(cfg))).sum
   }
 
   def hasIQWakeUp: Boolean = numWakeupFromIQ > 0 && numRegSrc > 0

--- a/src/main/scala/xiangshan/backend/issue/Scheduler.scala
+++ b/src/main/scala/xiangshan/backend/issue/Scheduler.scala
@@ -29,10 +29,11 @@ case class NoScheduler() extends SchedulerType
 class Scheduler(val params: SchdBlockParams)(implicit p: Parameters) extends LazyModule with HasXSParameter {
   override def shouldBeInlined: Boolean = false
 
-  val numIntStateWrite = backendParams.numPregWb(IntData())
-  val numVfStateWrite = backendParams.numPregWb(VecData())
-  val numV0StateWrite = backendParams.numPregWb(V0Data())
-  val numVlStateWrite = backendParams.numPregWb(VlData())
+  val numIntStateWrite = backendParams.numPregWb(backendParams.intPregParams)
+  // val numFpStateWrite = backendParams.numPregWb(backendParams.fpPregParams)
+  val numVfStateWrite = backendParams.numPregWb(backendParams.vfPregParams)
+  val numV0StateWrite = backendParams.numPregWb(backendParams.v0PregParams)
+  val numVlStateWrite = backendParams.numPregWb(backendParams.vlPregParams)
 
   val dispatch2Iq = LazyModule(new Dispatch2Iq(params))
   val issueQueue = params.issueBlockParams.map(x => LazyModule(new IssueQueue(x).suggestName(x.getIQName)))
@@ -67,14 +68,11 @@ class SchedulerIO()(implicit params: SchdBlockParams, p: Parameters) extends XSB
     val allocPregs = Vec(RenameWidth, Input(new ResetPregStateReq))
     val uops =  Vec(params.numUopIn, Flipped(DecoupledIO(new DynInst)))
   }
-  val intWriteBack = MixedVec(Vec(backendParams.numPregWb(IntData()),
-    new RfWritePortWithConfig(backendParams.intPregParams.dataCfg, backendParams.intPregParams.addrWidth)))
-  val vfWriteBack = MixedVec(Vec(backendParams.numPregWb(VecData()),
-    new RfWritePortWithConfig(backendParams.vfPregParams.dataCfg, backendParams.vfPregParams.addrWidth)))
-  val v0WriteBack = MixedVec(Vec(backendParams.numPregWb(V0Data()),
-    new RfWritePortWithConfig(backendParams.v0PregParams.dataCfg, backendParams.v0PregParams.addrWidth)))
-  val vlWriteBack = MixedVec(Vec(backendParams.numPregWb(VlData()),
-    new RfWritePortWithConfig(backendParams.vlPregParams.dataCfg, backendParams.vlPregParams.addrWidth)))
+  val intWriteBack = MixedVec(Vec(backendParams.numPregWb(backendParams.intPregParams), new RfWritePortWithConfig(backendParams.intPregParams)))
+  // val fpWriteBack = MixedVec(Vec(backendParams.numPregWb(backendParams.fpPregParams),new RfWritePortWithConfig(backendParams.vfPregParams)))
+  val vfWriteBack = MixedVec(Vec(backendParams.numPregWb(backendParams.vfPregParams),new RfWritePortWithConfig(backendParams.vfPregParams)))
+  val v0WriteBack = MixedVec(Vec(backendParams.numPregWb(backendParams.v0PregParams),new RfWritePortWithConfig(backendParams.v0PregParams)))
+  val vlWriteBack = MixedVec(Vec(backendParams.numPregWb(backendParams.vlPregParams),new RfWritePortWithConfig(backendParams.vlPregParams)))
   val toDataPathAfterDelay: MixedVec[MixedVec[DecoupledIO[IssueQueueIssueBundle]]] = MixedVec(params.issueBlockParams.map(_.genIssueDecoupledBundle))
 
   val vlWriteBackInfo = new Bundle {

--- a/src/main/scala/xiangshan/backend/regfile/PregParams.scala
+++ b/src/main/scala/xiangshan/backend/regfile/PregParams.scala
@@ -2,13 +2,19 @@ package xiangshan.backend.regfile
 
 import chisel3.util.log2Up
 import xiangshan.backend.datapath.DataConfig._
+import xiangshan.backend.datapath.RdConfig._
+import xiangshan.backend.datapath.WbConfig._
+
+trait regPort
 
 abstract class PregParams {
   val numEntries: Int
   val numRead: Option[Int]
   val numWrite: Option[Int]
-  val dataCfg: DataConfig
+  val dataCfg: Set[DataConfig]
   val isFake: Boolean
+  val rdType: RdConfig
+  val wbType: PregWB
 
   def addrWidth = log2Up(numEntries)
 }
@@ -18,9 +24,10 @@ case class IntPregParams(
   numRead   : Option[Int],
   numWrite  : Option[Int],
 ) extends PregParams {
-
-  val dataCfg: DataConfig = IntData()
+  val dataCfg: Set[DataConfig] = Set(IntData())
   val isFake: Boolean = false
+  val rdType: RdConfig = IntRD()
+  val wbType: PregWB = IntWB()
 }
 
 // case class FpPregParams(
@@ -38,9 +45,10 @@ case class VfPregParams(
   numRead   : Option[Int],
   numWrite  : Option[Int],
 ) extends PregParams {
-
-  val dataCfg: DataConfig = VecData()
+  val dataCfg: Set[DataConfig] = Set(VecData(), FpData())
   val isFake: Boolean = false
+  val rdType: RdConfig = VfRD()
+  val wbType: PregWB = VfWB()
 }
 
 case class V0PregParams(
@@ -49,8 +57,10 @@ case class V0PregParams(
   numWrite  : Option[Int],
 ) extends PregParams {
 
-  val dataCfg: DataConfig = V0Data()
+  val dataCfg: Set[DataConfig] = Set(V0Data())
   val isFake: Boolean = false
+  val rdType: RdConfig = V0RD()
+  val wbType: PregWB = V0WB()
 }
 
 case class VlPregParams(
@@ -59,8 +69,10 @@ case class VlPregParams(
   numWrite  : Option[Int],
 ) extends PregParams {
 
-  val dataCfg: DataConfig = VlData()
+  val dataCfg: Set[DataConfig] = Set(VlData())
   val isFake: Boolean = false
+  val rdType: RdConfig = VlRD()
+  val wbType: PregWB = VlWB()
 }
 
 case class NoPregParams() extends PregParams {
@@ -68,8 +80,10 @@ case class NoPregParams() extends PregParams {
   val numRead   : Option[Int] = None
   val numWrite  : Option[Int] = None
 
-  val dataCfg: DataConfig = NoData()
+  val dataCfg: Set[DataConfig] = Set()
   val isFake: Boolean = false
+  val rdType: RdConfig = NoRD()
+  val wbType: PregWB = NoWB()
 }
 
 case class FakeIntPregParams(
@@ -78,6 +92,8 @@ case class FakeIntPregParams(
   numWrite  : Option[Int],
 ) extends PregParams {
 
-  val dataCfg: DataConfig = FakeIntData()
+  val dataCfg: Set[DataConfig] = Set(FakeIntData())
   val isFake: Boolean = true
+  val rdType: RdConfig = NoRD()
+  val wbType: PregWB = NoWB()
 }

--- a/src/main/scala/xiangshan/backend/regfile/Regfile.scala
+++ b/src/main/scala/xiangshan/backend/regfile/Regfile.scala
@@ -34,28 +34,23 @@ class RfWritePort(dataWidth: Int, addrWidth: Int) extends Bundle {
   val data = Input(UInt(dataWidth.W))
 }
 
-class RfReadPortWithConfig(val rfReadDataCfg: DataConfig, addrWidth: Int) extends Bundle {
+class RfReadPortWithConfig(addrWidth: Int) extends Bundle {
   val addr: UInt = Input(UInt(addrWidth.W))
   val srcType: UInt = Input(UInt(3.W))
-
-  def readInt: Boolean = IntRegSrcDataSet.contains(rfReadDataCfg)
-  def readVec: Boolean = VecRegSrcDataSet.contains(rfReadDataCfg)
-  def readVf : Boolean = VecRegSrcDataSet .contains(rfReadDataCfg)
 }
 
-class RfWritePortWithConfig(val rfWriteDataCfg: DataConfig, addrWidth: Int) extends Bundle {
+class RfWritePortWithConfig(pregParams: PregParams) extends Bundle {
+  val addrWidth = pregParams.addrWidth
+  val dataWidth = pregParams.dataCfg.map(_.dataWidth).max
+
   val wen = Input(Bool())
   val addr = Input(UInt(addrWidth.W))
-  val data = Input(UInt(rfWriteDataCfg.dataWidth.W))
+  val data = Input(UInt(dataWidth.W))
   val intWen = Input(Bool())
   val fpWen = Input(Bool())
   val vecWen = Input(Bool())
   val v0Wen = Input(Bool())
   val vlWen = Input(Bool())
-  def writeInt: Boolean = rfWriteDataCfg.isInstanceOf[IntData]
-  def writeVec: Boolean = rfWriteDataCfg.isInstanceOf[VecData]
-  def writeV0 : Boolean = rfWriteDataCfg.isInstanceOf[V0Data]
-  def writeVl : Boolean = rfWriteDataCfg.isInstanceOf[VlData]
 }
 
 class Regfile


### PR DESCRIPTION
Since both FpData and VecData can write into vector regfile, data config and regfile port config should be decoupled.
In addition, bind regfile config and regfile port config for parameters calculation.